### PR TITLE
BUG: Tramites comerciales. El botón de rechazar no aparece en "Esperando documentación"

### DIFF
--- a/components/SearchResultItem.vue
+++ b/components/SearchResultItem.vue
@@ -1,0 +1,168 @@
+<template>
+  <a
+    v-if="isExternalLink"
+    :href="to"
+    target="_blank"
+    rel="noopener noreferrer"
+    class="search-result-link"
+  >
+    <div
+      class="d-flex w-100 white shadow-card search-result-card align-items-center"
+      :class="{ 'search-result-card--compact': compact }"
+    >
+      <div class="text-start my-auto flex-grow-1 search-result-text" :class="{ 'search-result-text--compact': compact }">
+        <span v-if="section" class="search-result-badge">{{ section }}</span>
+        <component :is="compact ? 'h6' : 'h3'" class="landing-text search-result-title mb-1"><b>{{ title }}</b></component>
+        <p v-if="compact" class="mb-0 search-result-description">{{ description }}</p>
+        <h6 v-else class="mb-0 search-result-description">{{ description }}</h6>
+      </div>
+    </div>
+  </a>
+  <NuxtLink v-else :to="to" class="search-result-link">
+    <div
+      class="d-flex w-100 white shadow-card search-result-card align-items-center"
+      :class="{ 'search-result-card--compact': compact }"
+    >
+      <div class="text-start my-auto flex-grow-1 search-result-text" :class="{ 'search-result-text--compact': compact }">
+        <span v-if="section" class="search-result-badge">{{ section }}</span>
+        <component :is="compact ? 'h6' : 'h3'" class="landing-text search-result-title mb-1"><b>{{ title }}</b></component>
+        <p v-if="compact" class="mb-0 search-result-description">{{ description }}</p>
+        <h6 v-else class="mb-0 search-result-description">{{ description }}</h6>
+      </div>
+    </div>
+  </NuxtLink>
+</template>
+
+<script>
+export default {
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    description: {
+      type: String,
+      default: '',
+    },
+    to: {
+      type: String,
+      required: true,
+    },
+    section: {
+      type: String,
+      default: '',
+    },
+    external: {
+      type: Boolean,
+      default: false,
+    },
+    compact: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    isExternalLink() {
+      return this.external || /^https?:\/\//i.test(this.to)
+    },
+  },
+}
+</script>
+
+<style scoped>
+.search-result-link {
+  color: inherit;
+  display: block;
+  width: 100%;
+  text-decoration: none !important;
+}
+
+.search-result-link:hover,
+.search-result-link:focus,
+.search-result-link:focus-visible,
+.search-result-link:active,
+.search-result-link:visited {
+  color: inherit;
+  text-decoration: none !important;
+}
+
+.search-result-link :is(h3, h6, b, p, span, small) {
+  text-decoration: none !important;
+}
+
+.search-result-card {
+  padding: 0.5rem 0;
+  border: 1px solid rgba(12, 104, 26, 0.15);
+  border-radius: 0.375rem;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+  cursor: pointer;
+}
+
+.search-result-link:hover .search-result-card {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  transform: translateY(-1px);
+}
+
+.search-result-text {
+  padding: 0.75rem 1.25rem;
+}
+
+.search-result-badge {
+  display: inline-block;
+  margin-bottom: 0.45rem;
+  padding: 0.15rem 0.55rem;
+  border-radius: 0.25rem;
+  background-color: rgba(12, 104, 26, 0.12);
+  color: #0c681a;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
+
+.search-result-title {
+  line-height: 1.25;
+}
+
+.search-result-description {
+  color: #6c757d;
+  font-weight: 400;
+}
+
+.search-result-card--compact {
+  padding: 0;
+  box-shadow: none;
+  border-color: rgba(12, 104, 26, 0.1);
+}
+
+.search-result-text--compact {
+  padding: 0.5rem 0.75rem;
+}
+
+.search-result-card--compact .search-result-badge {
+  font-size: 0.7rem;
+  margin-bottom: 0.3rem;
+  padding: 0.1rem 0.45rem;
+}
+
+.search-result-card--compact .search-result-title {
+  font-size: 0.95rem;
+}
+
+.search-result-card--compact .search-result-description {
+  font-size: 0.8rem;
+}
+
+@media (max-width: 767.98px) {
+  .search-result-text {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .search-result-text--compact {
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+  }
+}
+</style>

--- a/components/SiteSearch.vue
+++ b/components/SiteSearch.vue
@@ -1,0 +1,155 @@
+<template>
+  <section class="search-hero main-background" aria-labelledby="site-search-label">
+    <div class="search-hero-inner mx-auto">
+      <label
+        id="site-search-label"
+        :for="inputId"
+        class="search-hero-label"
+      >
+        ¿Qué trámite estás buscando?
+      </label>
+
+      <form class="search-hero-form" @submit.prevent="runSearch">
+        <div class="search-hero-controls">
+          <b-form-input
+            :id="inputId"
+            v-model="query"
+            type="search"
+            class="search-hero-input"
+            placeholder="Ej: habilitación, pagos dobles, normativa..."
+            autocomplete="off"
+            @keydown.esc="clearSearch"
+          />
+          <b-button
+            type="submit"
+            variant="primary"
+            class="search-hero-submit"
+          >
+            <i class="bi bi-search me-1" aria-hidden="true" />
+            Buscar
+          </b-button>
+        </div>
+      </form>
+    </div>
+  </section>
+</template>
+
+<script>
+export default {
+  props: {
+    initialQuery: {
+      type: String,
+      default: '',
+    },
+  },
+  data() {
+    return {
+      query: this.initialQuery,
+      inputId: `site-search-${Math.random().toString(36).slice(2, 9)}`,
+    }
+  },
+  watch: {
+    initialQuery(value) {
+      this.query = value || ''
+    },
+  },
+  methods: {
+    runSearch() {
+      const trimmed = this.query.trim()
+      if (!trimmed) {
+        this.clearSearch()
+        return
+      }
+
+      this.$router.push({
+        path: '/buscar',
+        query: { q: trimmed },
+      })
+    },
+    clearSearch() {
+      this.query = ''
+    },
+  },
+}
+</script>
+
+<style scoped>
+.search-hero {
+  width: 100%;
+  padding: 1.5rem 1.25rem 1.75rem;
+}
+
+.search-hero-inner {
+  width: 100%;
+  max-width: 960px;
+  padding: 0 0.5rem;
+}
+
+.search-hero-label {
+  display: block;
+  margin-bottom: 0.65rem;
+  font-weight: 600;
+  color: #0b6819;
+}
+
+.search-hero-form {
+  width: 100%;
+}
+
+.search-hero-controls {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+}
+
+.search-hero-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: none;
+  border-radius: 0.375rem 0 0 0.375rem;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  box-shadow: none;
+}
+
+.search-hero-input:focus {
+  box-shadow: none;
+  border-color: transparent;
+}
+
+.search-hero-submit {
+  flex: 0 0 auto;
+  border-radius: 0 0.375rem 0.375rem 0;
+  padding: 0.75rem 1.25rem;
+  font-weight: 700;
+  white-space: nowrap;
+  background-color: #2a43a1;
+  border-color: #2a43a1;
+}
+
+.search-hero-submit:hover,
+.search-hero-submit:focus {
+  background-color: #223687;
+  border-color: #223687;
+}
+
+@media (max-width: 575.98px) {
+  .search-hero {
+    padding: 1.25rem 1rem 1.5rem;
+  }
+
+  .search-hero-label {
+    font-size: 0.95rem;
+  }
+
+  .search-hero-input {
+    font-size: 0.95rem;
+    padding: 0.65rem 0.85rem;
+  }
+
+  .search-hero-submit {
+    padding: 0.65rem 0.9rem;
+    font-size: 0.95rem;
+  }
+}
+</style>

--- a/composables/useSiteSearch.js
+++ b/composables/useSiteSearch.js
@@ -1,0 +1,17 @@
+import {
+  filterSiteNavigationItems,
+  getVisibleSiteNavigationItems,
+} from '~/utils/siteNavigation'
+
+export function useSiteSearch() {
+  const userStore = useUserStore()
+
+  const visibleItems = computed(() => getVisibleSiteNavigationItems(userStore))
+
+  const search = (query) => filterSiteNavigationItems(visibleItems.value, query)
+
+  return {
+    visibleItems,
+    search,
+  }
+}

--- a/pages/buscar.vue
+++ b/pages/buscar.vue
@@ -1,0 +1,99 @@
+<template>
+  <div class="page main-background">
+    <Banner title="Buscador de trámites" subtitle="MUNICIPALIDAD DE VILLA GESELL" />
+    <SiteSearch :initial-query="submittedQuery" />
+
+    <section
+      v-if="hasQuery"
+      class="search-results mx-auto"
+      aria-live="polite"
+    >
+      <div v-if="results.length > 0">
+        <p class="search-results-count mb-2">
+          {{ results.length }} resultado{{ results.length === 1 ? '' : 's' }} para "{{ submittedQuery }}"
+        </p>
+        <div class="search-results-list">
+          <SearchResultItem
+            v-for="item in results"
+            :key="item.id"
+            :title="item.title"
+            :description="item.description"
+            :to="item.to"
+            :section="item.section"
+            :external="item.external"
+          />
+        </div>
+      </div>
+
+      <div v-else class="search-results-empty text-center">
+        <p class="mb-0">No se encontraron resultados para "{{ submittedQuery }}".</p>
+      </div>
+    </section>
+
+    <div class="page-btn-volver-wrap w-100">
+      <b-button variant="primary" size="sm" class="page-btn-volver" @click="$router.push('/')">
+        Volver
+      </b-button>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  setup() {
+    const { search } = useSiteSearch()
+    return { searchItems: search }
+  },
+  data() {
+    return {
+      submittedQuery: '',
+      results: [],
+    }
+  },
+  computed: {
+    hasQuery() {
+      return !!this.submittedQuery
+    },
+  },
+  watch: {
+    '$route.query.q': {
+      immediate: true,
+      handler(query) {
+        const trimmed = (query || '').trim()
+        this.submittedQuery = trimmed
+        this.results = trimmed ? this.searchItems(trimmed) : []
+      },
+    },
+  },
+}
+</script>
+
+<style scoped>
+.search-results {
+  width: 100%;
+  max-width: 960px;
+  margin-top: 1.25rem;
+  padding: 0 1.75rem 1.5rem;
+}
+
+.search-results-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.search-results-count {
+  color: #495057;
+  font-size: 0.95rem;
+}
+
+.search-results-empty {
+  color: #495057;
+}
+
+@media (max-width: 575.98px) {
+  .search-results {
+    padding: 0 1.25rem 1.25rem;
+  }
+}
+</style>

--- a/pages/comercio/solicitudes/[id].vue
+++ b/pages/comercio/solicitudes/[id].vue
@@ -99,6 +99,14 @@
           Finalizar solicitud
         </b-button>
         <b-button
+          v-if="jefeComercio && habilitacion && habilitacion.status === 'Esperando documentación'"
+          @click="onRechazarSolicitud"
+          size="sm"
+          class="btn-3"
+        >
+          Rechazar solicitud
+        </b-button>
+        <b-button
           v-if="adminMaster && habilitacion && habilitacion.status != 'En revisión'"
           size="sm"
           variant="secondary"

--- a/pages/comercio/tramites/index.vue
+++ b/pages/comercio/tramites/index.vue
@@ -237,7 +237,7 @@
         </b-col>
         <b-col v-if="tramiteSeleccionado=='Habilitación'">
           <br />
-          <b-card class="section-card" id="card-baja" :class="{ expanded: isCardExpanded(5) }">
+          <b-card class="section-card" id="card-habilitacion" :class="{ expanded: isCardExpanded(5) }">
             <h4 class="section-title" @click="toggleCard(5)">
               ¿Qué significa realizar una Habilitacion Comercial?
               <i class="bi bi-chevron-compact-down"></i>
@@ -264,7 +264,7 @@
                 </div>
             </div>
           </b-card>
-          <b-card class="section-card" id="card-habilitacion" :class="{ expanded: isCardExpanded(6) }">
+          <b-card class="section-card" :class="{ expanded: isCardExpanded(6) }">
             <h4 class="section-title" @click="toggleCard(6)">
               ¿Quién puede iniciar una Habilitación Comercial?
               <i class="bi bi-chevron-compact-down"></i>
@@ -610,7 +610,7 @@
         </b-col>
         <b-col v-if="tramiteSeleccionado=='Renovación'">
           <br />
-          <b-card class="section-card" id="card-baja" :class="{ expanded: isCardExpanded(11) }">
+          <b-card class="section-card" id="card-renovacion" :class="{ expanded: isCardExpanded(11) }">
             <h4 class="section-title" @click="toggleCard(11)">
               ¿Qué significa realizar una Renovación Comercial?
               <i class="bi bi-chevron-compact-down"></i>
@@ -654,7 +654,7 @@
                 </div>
             </div>
           </b-card>
-          <b-card class="section-card" id="card-habilitacion" :class="{ expanded: isCardExpanded(12) }">
+          <b-card class="section-card" :class="{ expanded: isCardExpanded(12) }">
             <h4 class="section-title" @click="toggleCard(12)">
               ¿Quién puede iniciar una Renovación Comercial?
               <i class="bi bi-chevron-compact-down"></i>
@@ -785,7 +785,7 @@
         </b-col>
         <b-col v-if="tramiteSeleccionado=='Reempadronamiento'">
           <br />
-          <b-card class="section-card" id="card-baja" :class="{ expanded: isCardExpanded(17) }">
+          <b-card class="section-card" id="card-reempadronamiento" :class="{ expanded: isCardExpanded(17) }">
             <h4 class="section-title" @click="toggleCard(17)">
               ¿Qué significa realizar un Reempadronamiento Comercial?
               <i class="bi bi-chevron-compact-down"></i>
@@ -826,7 +826,7 @@
                 </div>
             </div>
           </b-card>
-          <b-card class="section-card" id="card-habilitacion" :class="{ expanded: isCardExpanded(18) }">
+          <b-card class="section-card" :class="{ expanded: isCardExpanded(18) }">
             <h4 class="section-title" @click="toggleCard(18)">
               ¿Quién puede iniciar un Reempadronamiento Comercial?
               <i class="bi bi-chevron-compact-down"></i>
@@ -961,7 +961,7 @@
         </b-col>
         <b-col v-if="tramiteSeleccionado=='Cambio de Titular'">
           <br />
-          <b-card class="section-card" id="card-baja" :class="{ expanded: isCardExpanded(22) }">
+          <b-card class="section-card" id="card-cambio-titular" :class="{ expanded: isCardExpanded(22) }">
             <h4 class="section-title" @click="toggleCard(22)">
               ¿Qué significa realizar un Cambio de Titular?
               <i class="bi bi-chevron-compact-down"></i>
@@ -1008,7 +1008,7 @@
                 </div>
             </div>
           </b-card>
-          <b-card class="section-card" id="card-habilitacion" :class="{ expanded: isCardExpanded(23) }">
+          <b-card class="section-card" :class="{ expanded: isCardExpanded(23) }">
             <h4 class="section-title" @click="toggleCard(23)">
               ¿Quién puede realizar un Cambio de Titular?
               <i class="bi bi-chevron-compact-down"></i>
@@ -1411,13 +1411,17 @@ const TRAMITE_BTN_IDS = {
   'Cambio de Titular': 'btn-Cambio-Titular',
 }
 
+/** Primer card de cada trámite (scroll al seleccionar). */
 const TRAMITE_SCROLL_IDS = {
   'Habilitación': 'card-habilitacion',
   Baja: 'card-baja',
-  'Renovación': 'card-baja',
-  Reempadronamiento: 'card-habilitacion',
-  'Cambio de Titular': 'card-habilitacion',
+  'Renovación': 'card-renovacion',
+  Reempadronamiento: 'card-reempadronamiento',
+  'Cambio de Titular': 'card-cambio-titular',
 }
+
+/** Trámites válidos (p. ej. desde ?tramite= del buscador). */
+const TRAMITES_VALIDOS = Object.keys(TRAMITE_BTN_IDS)
 
 export default {
   data:function() {
@@ -1482,6 +1486,10 @@ export default {
   },
   mounted() {
     this.filteredRubros.sort((a, b) => a.nombre.localeCompare(b.nombre));
+    const tramiteFromQuery = this.$route.query.tramite
+    if (typeof tramiteFromQuery === 'string' && TRAMITES_VALIDOS.includes(tramiteFromQuery)) {
+      this.seleccionarTramite(tramiteFromQuery)
+    }
   },
   computed:{
     // estaAbierto(){
@@ -1612,9 +1620,8 @@ export default {
       }
     })
 
-    ;[...this.expandedCards].forEach((card) => {
-      if (this.isCardExpanded(card)) this.toggleCard(card)
-    })
+    // Mostrar las secciones cerradas; se abren con click en el título
+    this.expandedCards = []
 
     this.$nextTick(() => {
       const scrollId = TRAMITE_SCROLL_IDS[tramite]

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="page main-background">
     <Banner title="SECRETARÍA DE HACIENDA" subtitle="MUNICIPALIDAD DE VILLA GESELL" />
-    <Landing/>
+    <SiteSearch />
+    <Landing />
   </div>
 </template>

--- a/utils/siteNavigation.js
+++ b/utils/siteNavigation.js
@@ -1,0 +1,466 @@
+import { COMBUSTIBLE_DASHBOARD_USERNAMES } from '~/utils/access-control'
+
+/**
+ * Índice de navegación buscable del sitio.
+ * Incluye MenuItems, trámites individuales y accesos externos frecuentes
+ * que no necesariamente aparecen en el menú.
+ *
+ * @typedef {Object} SiteNavItem
+ * @property {string} id
+ * @property {string} title
+ * @property {string} description
+ * @property {string} to
+ * @property {string} [section]
+ * @property {boolean} [external]
+ * @property {string[]} [aliases] Términos alternativos de búsqueda (ej. patente → automotor)
+ * @property {string[]} [adminRoles]
+ * @property {string[]} [allowedUsernames]
+ */
+
+/** @type {SiteNavItem[]} */
+export const SITE_NAVIGATION_ITEMS = [
+  // —— Inicio / landing ——
+  {
+    id: 'landing-normativa',
+    title: 'Normativa',
+    description: 'Normativa y digestos de Villa Gesell',
+    to: '/normativa',
+    section: 'Inicio',
+    aliases: ['digesto', 'ordenanzas', 'leyes'],
+  },
+  {
+    id: 'landing-modernizacion',
+    title: 'Modernización',
+    description: 'Recursos y documentación de modernización municipal',
+    to: '/modernizacion',
+    section: 'Inicio',
+    aliases: ['uso interno', 'documentación municipal'],
+  },
+  {
+    id: 'landing-comercio',
+    title: 'Comercio',
+    description: 'Trámites y servicios para comercios',
+    to: '/comercio',
+    section: 'Inicio',
+    aliases: ['local', 'negocio', 'habilitación comercial'],
+  },
+  {
+    id: 'landing-recaudaciones',
+    title: 'Recaudaciones',
+    description: 'Servicios de recaudación municipal',
+    to: '/recaudaciones',
+    section: 'Inicio',
+    aliases: ['tasas', 'impuestos', 'boletas'],
+  },
+  {
+    id: 'landing-pagos',
+    title: 'Pagos',
+    description: 'Portal de pagos municipales',
+    to: 'https://arvige.gob.ar/lpagos',
+    section: 'Inicio',
+    external: true,
+    aliases: ['pagar', 'boleta', 'descargar boleta', 'vencimientos'],
+  },
+  {
+    id: 'landing-compras',
+    title: 'Compras',
+    description: 'Licitaciones, proveedores y suministros',
+    to: '/compras',
+    section: 'Inicio',
+    aliases: ['licitaciones', 'proveedores', 'suministros'],
+  },
+  {
+    id: 'landing-arvige',
+    title: 'ARVIGE',
+    description: 'Agencia de Recaudación de Villa Gesell',
+    to: 'https://arvige.gob.ar',
+    section: 'Inicio',
+    external: true,
+    aliases: ['agencia de recaudación', 'contribuyente'],
+  },
+  {
+    id: 'landing-transito',
+    title: 'Tránsito',
+    description: 'Gestión de tránsito municipal',
+    to: '/transito',
+    section: 'Inicio',
+    adminRoles: ['hacienda', 'master'],
+    aliases: ['multas', 'infracciones'],
+  },
+  {
+    id: 'landing-obras',
+    title: 'Obras',
+    description: 'Obras públicas municipales',
+    to: '/obras',
+    section: 'Inicio',
+    adminRoles: ['hacienda', 'master'],
+    aliases: ['obra pública', 'construcción'],
+  },
+
+  // —— Comercio ——
+  {
+    id: 'comercio-tramites',
+    title: 'Trámites comerciales',
+    description: 'Realizar los trámites para tu comercio',
+    to: '/comercio/tramites',
+    section: 'Comercio',
+    aliases: ['trámites comercio', 'habilitaciones'],
+  },
+  {
+    id: 'comercio-abierto-anual',
+    title: 'Abierto Anual',
+    description: 'Acceder al formulario de Abierto Anual de comercios',
+    to: '/comercio/abierto_anual',
+    section: 'Comercio',
+    aliases: ['abierto', 'declaración jurada', 'ddjj', 'temporada'],
+  },
+  {
+    id: 'comercio-consulta-tramite',
+    title: 'Consulta estado de trámite',
+    description: 'Consultá el estado de tu trámite comercial',
+    to: '/comercio/consulta_tramite',
+    section: 'Comercio',
+    aliases: ['seguimiento', 'estado del trámite', 'consultar trámite', 'nro de trámite'],
+  },
+  {
+    id: 'comercio-turnos',
+    title: 'Turnos',
+    description: 'Obtener turnos para inspección de comercios',
+    to: '/comercio/turnos',
+    section: 'Comercio',
+    aliases: ['turno', 'inspección', 'agendar'],
+  },
+
+  // —— Trámites comerciales individuales ——
+  {
+    id: 'tramite-habilitacion',
+    title: 'Habilitación Comercial',
+    description: 'Iniciar el trámite de habilitación de un comercio',
+    to: '/comercio/tramites?tramite=Habilitación',
+    section: 'Trámites comerciales',
+    aliases: ['habilitar', 'permiso comercial', 'abrir comercio', 'nueva habilitación'],
+  },
+  {
+    id: 'tramite-baja',
+    title: 'Baja Comercial',
+    description: 'Finalizar una habilitación comercial vigente',
+    to: '/comercio/tramites?tramite=Baja',
+    section: 'Trámites comerciales',
+    aliases: ['cerrar comercio', 'dar de baja', 'clausura'],
+  },
+  {
+    id: 'tramite-renovacion',
+    title: 'Renovación Comercial',
+    description: 'Reafirmar la continuidad de una habilitación comercial',
+    to: '/comercio/tramites?tramite=Renovación',
+    section: 'Trámites comerciales',
+    aliases: ['renovar', 'renovación habilitación'],
+  },
+  {
+    id: 'tramite-reempadronamiento',
+    title: 'Reempadronamiento Comercial',
+    description: 'Reafirmar la continuidad de una habilitación en los mismos términos',
+    to: '/comercio/tramites?tramite=Reempadronamiento',
+    section: 'Trámites comerciales',
+    aliases: ['reempadronar', 'empadronamiento'],
+  },
+  {
+    id: 'tramite-cambio-titular',
+    title: 'Cambio de Titular',
+    description: 'Transferir la titularidad de una habilitación comercial',
+    to: '/comercio/tramites?tramite=Cambio de Titular',
+    section: 'Trámites comerciales',
+    aliases: ['cambio de titularidad', 'transferencia', 'cesión'],
+  },
+
+  // —— Compras ——
+  {
+    id: 'compras-licitaciones',
+    title: 'Licitaciones públicas',
+    description: 'Pliegos y notas aclaratorias para consulta',
+    to: 'https://hacienda.gesell.gob.ar/compras-y-suministros.html',
+    section: 'Compras',
+    external: true,
+    aliases: ['pliego', 'licitación', 'llamado'],
+  },
+  {
+    id: 'compras-proveedores',
+    title: 'Inscripción de proveedores',
+    description: 'Información acerca de la inscripción como Proveedor Municipal',
+    to: '/compras/proveedores',
+    section: 'Compras',
+    aliases: ['proveedor', 'registro de proveedores'],
+  },
+  {
+    id: 'compras-combustible',
+    title: 'Combustible',
+    description: 'Administrar órdenes de compra y vales de combustible',
+    to: '/compras/combustible',
+    section: 'Compras',
+    adminRoles: ['compras', 'master'],
+    allowedUsernames: COMBUSTIBLE_DASHBOARD_USERNAMES,
+    aliases: ['vales', 'nafta', 'gasoil', 'órdenes de compra'],
+  },
+
+  // —— Recaudaciones ——
+  {
+    id: 'recaudaciones-pagos-dobles',
+    title: 'Informar pagos dobles',
+    description: 'Realizar un reclamo por pago doble de tasas',
+    to: '/recaudaciones/pagos_dobles',
+    section: 'Recaudaciones',
+    aliases: ['pago doble', 'doble pago', 'pago duplicado', 'devolución', 'saldo excedente'],
+  },
+
+  // —— Normativa ——
+  {
+    id: 'normativa-comercio',
+    title: 'Digesto Comercial',
+    description: 'Normativa vigente para los comercios de Villa Gesell',
+    to: '/normativa/comercio',
+    section: 'Normativa',
+    aliases: ['ordenanzas comercio', 'reglamento comercial'],
+  },
+  {
+    id: 'normativa-obras',
+    title: 'Normativa de Obras Públicas',
+    description: 'Normativa vigente para Obras Públicas de la localidad de Villa Gesell',
+    to: '/normativa/obras',
+    section: 'Normativa',
+    aliases: ['ordenanzas obras', 'código de edificación'],
+  },
+
+  // —— Modernización (carpetas del menú interno) ——
+  {
+    id: 'modernizacion-procedimientos',
+    title: 'Procedimientos',
+    description: 'Documentación de procedimientos municipales',
+    to: '/modernizacion/procedimientos',
+    section: 'Modernización',
+    adminRoles: ['modernizacion', 'master'],
+    allowedUsernames: ['gustavociriaco@gesell.gob.ar'],
+    aliases: ['procedimiento', 'procesos', 'carpeta procedimientos'],
+  },
+  {
+    id: 'modernizacion-tutoriales',
+    title: 'Tutoriales',
+    description: 'Tutoriales de herramientas y sistemas municipales',
+    to: '/modernizacion/tutoriales',
+    section: 'Modernización',
+    adminRoles: ['modernizacion', 'master'],
+    allowedUsernames: ['gustavociriaco@gesell.gob.ar'],
+    aliases: ['tutorial', 'capacitaciones', 'cómo usar', 'carpeta tutoriales'],
+  },
+  {
+    id: 'modernizacion-notas',
+    title: 'Formularios / Notas tipo',
+    description: 'Formularios y notas tipo para uso interno',
+    to: '/modernizacion/notas',
+    section: 'Modernización',
+    adminRoles: ['modernizacion', 'cultura', 'master'],
+    allowedUsernames: ['gustavociriaco@gesell.gob.ar'],
+    aliases: ['formularios', 'notas tipo', 'notas', 'templates', 'modelos'],
+  },
+  {
+    id: 'modernizacion-tutorial-mail',
+    title: 'Mail institucional',
+    description: 'Tutorial de correo institucional',
+    to: '/modernizacion/tutoriales/mail-institucional',
+    section: 'Tutoriales',
+    adminRoles: ['modernizacion', 'master'],
+    allowedUsernames: ['gustavociriaco@gesell.gob.ar'],
+    aliases: ['correo', 'email', 'mail', 'webmail', 'gesell.gob.ar'],
+  },
+  {
+    id: 'modernizacion-tutorial-gde',
+    title: 'Sistema GDE',
+    description: 'Tutorial del sistema de Gestión Documental Electrónica',
+    to: '/modernizacion/tutoriales/gde',
+    section: 'Tutoriales',
+    adminRoles: ['modernizacion', 'master'],
+    allowedUsernames: ['gustavociriaco@gesell.gob.ar'],
+    aliases: ['gde', 'gestión documental', 'documentos electrónicos'],
+  },
+  {
+    id: 'modernizacion-tutorial-otros',
+    title: 'Otros tutoriales',
+    description: 'Otros tutoriales de modernización',
+    to: '/modernizacion/tutoriales/otros',
+    section: 'Tutoriales',
+    adminRoles: ['modernizacion', 'master'],
+    allowedUsernames: ['gustavociriaco@gesell.gob.ar'],
+    aliases: ['otros', 'más tutoriales'],
+  },
+
+  // —— Accesos frecuentes que no están como MenuItem en este sitio ——
+  {
+    id: 'arvige-pagos-online',
+    title: 'Pagá online / Descargá tu boleta',
+    description: 'Descargar boletas y pagar tasas municipales online (ARVIGE)',
+    to: 'https://arvige.gob.ar/lpagos',
+    section: 'ARVIGE',
+    external: true,
+    aliases: [
+      'pagar online',
+      'descargar boleta',
+      'imprimir boleta',
+      'vencimientos',
+      'lpagos',
+    ],
+  },
+  {
+    id: 'arvige-autogestion',
+    title: 'Autogestión ARVIGE',
+    description: 'Ingresá a tu cuenta de contribuyente para gestionar pagos',
+    to: 'https://autogestion.arvige.gob.ar/',
+    section: 'ARVIGE',
+    external: true,
+    aliases: ['autogestión', 'mi cuenta', 'contribuyente online', 'login arvige'],
+  },
+  {
+    id: 'arvige-patente-automotor',
+    title: 'Patente Automotor',
+    description: 'Consulta y pago de patente de vehículos automotores',
+    to: 'https://arvige.gob.ar/lpagos',
+    section: 'ARVIGE',
+    external: true,
+    aliases: [
+      'patente',
+      'automotor',
+      'rodado',
+      'rodados',
+      'vehículo',
+      'vehiculo',
+      'auto',
+      'impuesto automotor',
+      'patente automotor',
+    ],
+  },
+  {
+    id: 'arvige-patente-rodados-menores',
+    title: 'Patente — Rodados Menores',
+    description: 'Consulta y pago de patente de rodados menores',
+    to: 'https://arvige.gob.ar/lpagos',
+    section: 'ARVIGE',
+    external: true,
+    aliases: ['moto', 'motocicleta', 'ciclomotor', 'rodado menor', 'patente moto'],
+  },
+  {
+    id: 'arvige-tasas-urbanas',
+    title: 'Tasas Urbanas',
+    description: 'Consulta y pago de tasas urbanas municipales',
+    to: 'https://arvige.gob.ar/lpagos',
+    section: 'ARVIGE',
+    external: true,
+    aliases: [
+      'tasa urbana',
+      'servicios urbanos',
+      'tasa municipal',
+      'impuesto municipal',
+      'inmueble',
+      'cuenta municipal',
+    ],
+  },
+  {
+    id: 'arvige-tish',
+    title: 'TISH — Tasa de Inspección de Seguridad e Higiene',
+    description: 'Consulta y pago de TISH / grandes contribuyentes',
+    to: 'https://arvige.gob.ar/lpagos',
+    section: 'ARVIGE',
+    external: true,
+    aliases: ['tish', 'seguridad e higiene', 'inspección de seguridad', 'grandes contribuyentes'],
+  },
+  {
+    id: 'arvige-red-vial',
+    title: 'Red Vial',
+    description: 'Consulta y pago de tasa de red vial',
+    to: 'https://arvige.gob.ar/lpagos',
+    section: 'ARVIGE',
+    external: true,
+    aliases: ['red vial', 'vialidad'],
+  },
+  {
+    id: 'contribuyente-tasas',
+    title: 'Imprimir tasas municipales',
+    description: 'Imprimí las tasas municipales vigentes con tu número de cuenta',
+    to: 'https://contribuyente.gesell.gob.ar/tasas-municipales.html',
+    section: 'Recaudaciones',
+    external: true,
+    aliases: ['imprimir tasa', 'número de cuenta', 'contribuyente'],
+  },
+]
+
+/**
+ * Normaliza texto para comparación (minúsculas, sin tildes).
+ * @param {string} value
+ * @returns {string}
+ */
+function normalizeSearchText(value) {
+  return String(value || '')
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+}
+
+/**
+ * @param {import('../stores/user.js').useUserStore} userStore
+ * @param {SiteNavItem} item
+ */
+export function isSiteNavItemVisible(userStore, item) {
+  const hasRoleRestriction = Array.isArray(item.adminRoles) && item.adminRoles.length > 0
+  const hasUsernameRestriction = Array.isArray(item.allowedUsernames) && item.allowedUsernames.length > 0
+
+  if (!hasRoleRestriction && !hasUsernameRestriction) {
+    return true
+  }
+
+  const admin = userStore?.admin
+  const username = userStore?.username
+
+  if (hasRoleRestriction && item.adminRoles.includes(admin)) {
+    return true
+  }
+
+  if (hasUsernameRestriction && item.allowedUsernames.includes(username)) {
+    return true
+  }
+
+  return false
+}
+
+/**
+ * @param {import('../stores/user.js').useUserStore} userStore
+ * @returns {SiteNavItem[]}
+ */
+export function getVisibleSiteNavigationItems(userStore) {
+  return SITE_NAVIGATION_ITEMS.filter((item) => isSiteNavItemVisible(userStore, item))
+}
+
+/**
+ * @param {SiteNavItem} item
+ * @returns {string}
+ */
+function buildSearchHaystack(item) {
+  const parts = [
+    item.title,
+    item.description,
+    item.section,
+    ...(Array.isArray(item.aliases) ? item.aliases : []),
+  ]
+
+  return normalizeSearchText(parts.filter(Boolean).join(' '))
+}
+
+/**
+ * @param {SiteNavItem[]} items
+ * @param {string} query
+ * @returns {SiteNavItem[]}
+ */
+export function filterSiteNavigationItems(items, query) {
+  const term = normalizeSearchText(query.trim())
+  if (!term) {
+    return []
+  }
+
+  return items.filter((item) => buildSearchHaystack(item).includes(term))
+}


### PR DESCRIPTION
Trello: https://trello.com/c/BTv6nF6f
Proyecto: haciendavgesell

### Resumen del agente
### haciendavgesell/front @ feat/BTv6nF6f-bug-tramites-comerciales-el-boton-de-rec
Agente finished
**Corregido** en `pages/comercio/solicitudes/[id].vue`.

El modal y la lógica de rechazo (`onRechazarSolicitud` / `onSendReject`) ya existían, pero solo se activaban desde "En revisión" al finalizar con elementos incorrectos. No había botón visible en "Esperando documentación".

**Cambio:** se agregó el botón "Rechazar solicitud" (`btn-3`) en la barra de acciones cuando `jefeComercio` y el estado es `Esperando documentación`, junto a "Finalizar solicitud".

**Para verificar:** abrir un trámite en ese estado con usuario jefe de comercio y confirmar que aparece el botón y que el modal de rechazo funciona.