### PR TITLE
BUGS Abierto anual

### DIFF
--- a/components/comercio/AbiertoAnualAdminCard.vue
+++ b/components/comercio/AbiertoAnualAdminCard.vue
@@ -200,7 +200,7 @@
                   <b-button @click="RechazarTicket" variant="danger" class="btn-cancel"><span>Rechazar</span></b-button>
               </div>
               <div v-else-if="estadoActual == 3 || estadoActual == 4 || estadoActual == 5" class="card-actions-row card-actions-row-center">
-                  <i class="bi bi-pencil-square text-dark"></i>
+                  <i class="bi bi-pencil-square text-dark btn-rectific" role="button" tabindex="0" @click="RectificarTicket"></i>
               </div>
           </div>
       </div>
@@ -453,11 +453,15 @@ export default {
         switch (this.estadoActual) {
             case 9:
                 nextCard = 7;
-                facturas[this.periodo] = {
-                    contenido: facturas[this.periodo].contenido,
-                    rectificando: true,
-                };
                 status[this.periodo] = "Incorrecto";
+                if (facturas[this.periodo]) {
+                    facturas[this.periodo] = {
+                        ...facturas[this.periodo],
+                        rectificando: true,
+                    };
+                } else {
+                    facturas[this.periodo] = { rectificando: true };
+                }
                 break;
             case 10:
                 nextCard = 3;


### PR DESCRIPTION
Trello: https://trello.com/c/JJdp9sSy
Proyecto: haciendavgesell

### Resumen del agente
### haciendavgesell/front @ feat/JJdp9sSy-bugs-abierto-anual
Agente finished en D:/dev/Redeterminación/front
Listo. Cambio mínimo en `AvanzarPaso`, case 9.

### Qué se corrigió

Antes, la rectificación manual asumía que ya existía una factura y accedía a `facturas[periodo].contenido`, lo que fallaba cuando el slot era `null` (por ejemplo, período vencido sin carga — estado 5).

Ahora:

- Si `facturas[periodo]` es `null` → se envía `{ rectificando: true }` con `status = "Incorrecto"`.
- Si existe → se preservan todos los campos existentes (`url`, `contenido`, `observaciones`, etc.) y solo se agrega `rectificando: true`.

```454:465:components/comercio/AbiertoAnualAdminCard.vue
            case 9:
                nextCard = 7;
                status[this.periodo] = "Incorrecto";
                if (facturas[this.periodo]) {
                    facturas[this.periodo] = {
                        ...facturas[this.periodo],
                        rectificando: true,
                    };
                } else {
                    facturas[this.periodo] = { rectificando: true };
                }
                break;
```

### Notas

- **Case 12** no lo toqué: solo se alcanza desde rechazo en revisión (estados 2/8), donde siempre hay factura cargada.
- El diff previo del ícono de rectificac

### haciendavgesell/back @ feat/JJdp9sSy-bugs-abierto-anual
Agente finished en D:/dev/Redeterminación/redeterminacion
## Listo — cambios aplicados (sin commit)

### Front (1/2) — `AbiertoAn