### PR TITLE
Fix cast ObjectId en serviciosHoteleria al crear tramite

### DIFF
--- a/pages/comercio/tramites/form.vue
+++ b/pages/comercio/tramites/form.vue
@@ -1733,7 +1733,14 @@
               }
 
               // 4) Crear trámite solo con metadatos + URLs (JSON chico)
-              const { ningunaAnterior, ...inmuebleParaEnviar } = this.inmueble;
+              const { ningunaAnterior, ...inmuebleSinNinguna } = this.inmueble;
+              // No enviar `id` de UI: Mongoose lo interpreta como `_id` y falla el cast a ObjectId.
+              const inmuebleParaEnviar = {
+                ...inmuebleSinNinguna,
+                serviciosHoteleria: (this.inmueble.serviciosHoteleria || []).map(
+                  ({ servicio, value }) => ({ servicio, value })
+                ),
+              };
 
               const habilitacion = {
                 documentos: documentosParaGuardar,


### PR DESCRIPTION
﻿## Summary
- Evita enviar el id de UI de servicios de hoteleria en el payload del tramite comercial.
- Previene el 400 de Mongoose al castear ids "1".."12" como ObjectId.

## Test plan
- [ ] Crear una habilitacion y confirmar que el POST crea el tramite (201).
- [ ] Verificar que no aparece el error de serviciosHoteleria.
