### PR TITLE
Mostrar datos de solicitud en turnos de inspeccion

### DIFF
--- a/pages/comercio/turnos/[id].vue
+++ b/pages/comercio/turnos/[id].vue
@@ -16,14 +16,6 @@
             <span :class="turnoStatusClass" class="ml-2">{{ turno.status }}</span>
           </div>
         </div>
-        <div
-          v-if="turno.nroLegajoComercial"
-          class="row justify-content-center mt-3"
-        >
-          <p class="h5 mb-0">
-            Legajo comercial: <b>{{ turno.nroLegajoComercial }}</b>
-          </p>
-        </div>
       </div>
       <div v-if="adminInspeccion" class="solicitud-quick-actions">
         <b-button size="sm" variant="success" class="btn-4" @click="onAprobar">Aprobar inspección</b-button>

--- a/pages/comercio/turnos/[id].vue
+++ b/pages/comercio/turnos/[id].vue
@@ -16,6 +16,14 @@
             <span :class="turnoStatusClass" class="ml-2">{{ turno.status }}</span>
           </div>
         </div>
+        <div
+          v-if="turno.nroLegajoComercial"
+          class="row justify-content-center mt-3"
+        >
+          <p class="h5 mb-0">
+            Legajo comercial: <b>{{ turno.nroLegajoComercial }}</b>
+          </p>
+        </div>
       </div>
       <div v-if="adminInspeccion" class="solicitud-quick-actions">
         <b-button size="sm" variant="success" class="btn-4" @click="onAprobar">Aprobar inspección</b-button>
@@ -45,7 +53,23 @@
               <strong>Nombre del solicitante</strong><br>
             </p>
             <p class="col col-complementary" role="complementary">
-              <a>{{ turno.nombre}}</a>
+              <a>{{ turno.nombreSolicitante || '—' }}</a>
+            </p>
+          </div>
+          <div class="layout">
+            <p class="col col-main">
+              <strong>Nombre del turno</strong><br>
+            </p>
+            <p class="col col-complementary" role="complementary">
+              <a>{{ nombreTurnoDisplay }}</a>
+            </p>
+          </div>
+          <div v-if="turno.nroLegajoComercial" class="layout">
+            <p class="col col-main">
+              <strong>Número de legajo comercial</strong><br>
+            </p>
+            <p class="col col-complementary" role="complementary">
+              <a>{{ turno.nroLegajoComercial }}</a>
             </p>
           </div>
           <div class="layout">
@@ -269,6 +293,11 @@ export default {
         'Inspección rechazada': 'text-danger',
       }
       return classes[this.turno?.status] || ''
+    },
+    nombreTurnoDisplay() {
+      const t = this.turno
+      if (!t) return '—'
+      return t.nombreTurno ?? t.nombre ?? '—'
     },
   },
   methods: {

--- a/pages/comercio/turnos/reservas.vue
+++ b/pages/comercio/turnos/reservas.vue
@@ -33,6 +33,15 @@
         <template #cell(status)="row">
           <div :class="row.item.estadoColor"><b>{{ row.value }}</b></div>
         </template>
+        <template #cell(nroLegajoComercial)="row">
+          <span>{{ row.value || '—' }}</span>
+        </template>
+        <template #cell(nombreSolicitante)="row">
+          <span>{{ row.item.nombreSolicitante || '—' }}</span>
+        </template>
+        <template #cell(nombreTurno)="row">
+          <span>{{ row.item.nombreTurno ?? row.item.nombre ?? '—' }}</span>
+        </template>
         <!-- Plantilla personalizada para la columna "detalles" -->
         <template #cell(detalles)="row">
         <NuxtLink :to="{ name: 'comercio-turnos-id', params: { id: row.item.id } }" @click="registrarActividad('Abrir Turno', 'Turno nro: ' + row.item.nroTramite)">
@@ -91,6 +100,10 @@ export default{
           label: 'Tipo de trámite',
         },
         {
+          key: 'nroLegajoComercial',
+          label: 'Legajo comercial',
+        },
+        {
           key: 'dia',
           label: 'Fecha de inspección',
           sortable: true,
@@ -100,8 +113,12 @@ export default{
           label: 'Horario',
         },
         {
-          key: 'nombre',
-          label: 'Nombre',
+          key: 'nombreSolicitante',
+          label: 'Nombre del solicitante',
+        },
+        {
+          key: 'nombreTurno',
+          label: 'Nombre del turno',
         },
         {
           key: 'domicilio',

--- a/service/turno.js
+++ b/service/turno.js
@@ -10,6 +10,9 @@
   nroTramite: TurnoResponse.nroTramite,
   observaciones: TurnoResponse.observaciones,
   tipoTramite: TurnoResponse.tipoTramite,
+  nombreSolicitante: TurnoResponse.nombreSolicitante ?? null,
+  nombreTurno: TurnoResponse.nombreTurno ?? TurnoResponse.nombre ?? null,
+  nroLegajoComercial: TurnoResponse.nroLegajoComercial ?? null,
   createdAt: new Date(TurnoResponse.createdAt).toLocaleDateString('es-AR'),
 })
 


### PR DESCRIPTION
﻿## Summary
- Muestra nombre del solicitante, nombre del turno y legajo comercial en listado y detalle de turnos de inspeccion.
- Quita el legajo duplicado del resumen superior del detalle (queda solo en Datos del turno).

## Test plan
- [ ] Listado de reservas: columnas nuevas visibles.
- [ ] Detalle: solicitante/turno/legajo (legajo solo si aplica).
- [ ] Turno sin solicitud asociada: campos con guion, sin romper la pantalla.
