### PR TITLE
Abierto anual: acomodar margins tarjetas

### DIFF
--- a/components/comercio/AbiertoAnualAdminCard.vue
+++ b/components/comercio/AbiertoAnualAdminCard.vue
@@ -683,8 +683,11 @@ export default {
 @import "~/assets/css/abierto-anual-card-shared.css";
 
 .abierto-anual-card-shell {
-  max-width: 30rem;
+  max-width: min(30rem, 100%);
   width: 100%;
+  box-sizing: border-box;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
 }
 
 @media (max-width: 1200px){

--- a/pages/comercio/abierto_anual/registros/[id].vue
+++ b/pages/comercio/abierto_anual/registros/[id].vue
@@ -13,7 +13,7 @@
           <p class="h5 mt-3 mb-0"> CUIT: <b> {{ tramite.cuit }}  </b></p>
         </div>
         <!--Datos de facturas-->
-        <div class="row no-gutters justify-content-center abierto-anual-registros-cards">
+        <div class="row justify-content-center abierto-anual-registros-cards g-3 g-lg-4">
           <b-col v-for="(periodo, index) in periodosEstado" :key="index" cols="12" sm="10" md="6" lg="4" xl="4">
               <AbiertoAnualAdminCard
               :id="index"
@@ -234,9 +234,17 @@
     margin: 1.5em;
   } */
 
-  .abierto-anual-registros-cards > .col {
-    padding: 0.5rem;
-    margin: 0;
+  .abierto-anual-registros-cards {
+    width: 100%;
+    max-width: min(92rem, 100%);
+    margin-left: auto;
+    margin-right: auto;
+    padding-left: clamp(1rem, 4vw, 2rem);
+    padding-right: clamp(1rem, 4vw, 2rem);
+    box-sizing: border-box;
+  }
+
+  .abierto-anual-registros-cards > [class*='col'] {
     display: flex;
     justify-content: center;
   }


### PR DESCRIPTION
Trello: https://trello.com/c/v94XHbDg
Proyecto: haciendavgesell

### Resumen del agente
### haciendavgesell/front @ feat/v94XHbDg-abierto-anual-acomodar-margins-tarjetas
Agente finished en D:/dev/Redeterminación/front
**Qué se hizo**

En el detalle de **Uso interno** (`/comercio/abierto_anual/registros/:id`):

1. **Grilla** — Se quitó `no-gutters` y se usaron gutters Bootstrap (`g-3` / `g-lg-4`) para separar las tres tarjetas en ~1366px.
2. **Contenedor** — Padding lateral con `clamp(1rem, 4vw, 2rem)` para que en mobile no lleguen al borde de la pantalla.
3. **Tarjeta admin** — Ajuste menor en el shell (`box-sizing` y padding horizontal) para que no “empujen” contra los bordes de la columna.

**Cómo probar**

- Desktop ~1366×768: tres tarjetas con espacio entre sí.
- Mobile: una por fila con margen a los lados.
- 1920×1080: sin cambios bruscos (siguen centradas con `max-width`).

No hice commit, push ni merge. Si querés, preparo el commit en español.