### PR TITLE
Uso interno comercio: cambios de visibilidad ux (radio buttons, etc)

### DIFF
--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -8,6 +8,19 @@ $color-orange-button: #eb8a0a;
 $color-gray-dark: #353535;
 $color-gray-light: #666;
 
+@mixin internal-use-form-control-visible {
+  width: 1.2em;
+  height: 1.2em;
+  border: 2px solid $color-gray-dark;
+  background-color: #d8d8d8;
+  cursor: pointer;
+
+  &:focus {
+    border-color: $color-gray-dark;
+    box-shadow: 0 0 0 0.2rem rgba($color-gray-dark, 0.28);
+  }
+}
+
 // ============================================
 // LAYOUT BASE
 // ============================================
@@ -223,6 +236,12 @@ body:not(.modal-open) #app-content {
     float: none;
     margin: 0;
     flex-shrink: 0;
+    @include internal-use-form-control-visible;
+
+    &:checked {
+      background-color: $color-green-primary;
+      border-color: $color-green-primary;
+    }
   }
 
   .form-check-label {
@@ -243,6 +262,44 @@ body:not(.modal-open) #app-content {
 .internal-use-table.internal-use-wide,
 .internal-use-pagination.internal-use-wide {
   max-width: min(92rem, 96vw);
+}
+
+.internal-use-detail-card {
+  width: 100%;
+  max-width: 36rem;
+  margin-left: auto;
+  margin-right: auto;
+
+  @media (max-width: 575.98px) {
+    max-width: calc(100% - 0.75rem);
+  }
+
+  > .container,
+  .container {
+    max-width: 100%;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+
+    @media (min-width: 576px) {
+      padding-left: 0.75rem;
+      padding-right: 0.75rem;
+    }
+  }
+
+  .form-check-input[type='radio'],
+  .form-check-input[type='checkbox'] {
+    @include internal-use-form-control-visible;
+  }
+
+  .form-check-input:checked {
+    background-color: #28a745;
+    border-color: #28a745;
+  }
+
+  .form-check-input[value='incorrecto']:checked {
+    background-color: #dc3545;
+    border-color: #dc3545;
+  }
 }
 
 .si-no-radios-row { margin-bottom: 0.5rem; }

--- a/pages/comercio/solicitudes/[id].vue
+++ b/pages/comercio/solicitudes/[id].vue
@@ -127,7 +127,7 @@
       </div>
 
       <!--Datos del solicitante-->
-      <b-card no-body class="container col-md-6 col-sm-8 shadow-card mt-4 mx-auto">
+      <b-card no-body class="internal-use-detail-card shadow-card mt-4 mx-auto">
           <div class="col mx-auto">
             <div class="container text-center mx-auto">
               <div class="row align-items-center">
@@ -218,7 +218,7 @@
     </template>
         <!-- Datos del inmueble -->
     <template v-if="habilitacion && adminComercio">
-      <div class="container col-md-6 col-sm-8 card shadow-card mt-4 mx-auto">
+      <div class="internal-use-detail-card card shadow-card mt-4 mx-auto">
           <div class="col mx-auto">
             <div class="container text-center mx-auto">
               <div class="row align-items-center">
@@ -344,7 +344,7 @@
     </template>
     <!-- Documentación -->
     <template v-if="habilitacion && adminComercio">
-      <div class="container col-md-6 col-sm-8 card shadow-card mt-4 mb-3 mx-auto">
+      <div class="internal-use-detail-card card shadow-card mt-4 mb-3 mx-auto">
         <!-- Resto del contenido del componente -->
         <div class="col mx-auto">
           <div class="container text-center mx-auto">
@@ -435,7 +435,7 @@
 
     <!-- Turno (de existir) -->
     <template v-if="habilitacion && turno && adminComercio">
-      <div class="container col-md-6 col-sm-8 card shadow-card mt-4 mb-3 mx-auto">
+      <div class="internal-use-detail-card card shadow-card mt-4 mb-3 mx-auto">
         <!-- Resto del contenido del componente -->
         <div class="col mx-auto">
           <div class="container text-center mx-auto">
@@ -1877,16 +1877,6 @@ Importante: La documentación que adjunte debe ser legible y en formato PDF o im
 /* Estilos para los controles de revisión */
 .form-check-inline {
   margin-right: 0.5rem;
-}
-
-.form-check-input:checked {
-  background-color: #28a745;
-  border-color: #28a745;
-}
-
-.form-check-input[value="incorrecto"]:checked {
-  background-color: #dc3545;
-  border-color: #dc3545;
 }
 
 .form-check-label {


### PR DESCRIPTION
Trello: https://trello.com/c/1GkX1lbH
Proyecto: haciendavgesell

### Resumen del agente
### haciendavgesell/front @ feat/1GkX1lbH-uso-interno-comercio-cambios-de-visibili
Agente finished en D:/dev/Redeterminación/front
## Cambios

**Detalle de solicitud (uso interno comercio)** — `pages/comercio/solicitudes/[id].vue`  
- Las cards dejaron de usar `container col-md-6 col-sm-8` (doble padding en mobile) y pasaron a la clase `internal-use-detail-card`.

**Estilos globales** — `assets/css/custom.scss`  
- Mixin `internal-use-form-control-visible`: radios/checkbox con borde `#353535`, relleno gris y tamaño un poco mayor.  
- En detalle: correcto/incorrecto sigue en verde/rojo al marcar.  
- En listados (`internal-use-checkbox-row`, p. ej. solicitudes/turnos): mismo criterio visual.  
- `.internal-use-detail-card`: ancho máximo ~36rem, en mobile casi todo el ancho y menos padding en contenedores internos.

El build de producción terminó bien. Cambios sin commit ni push, como pediste.

**Para probar:** detalle de una solicitud en revisión (mobile y desktop) y listado con “Ocultar inspeccionados”.